### PR TITLE
transition.abort() causes 500 responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function fastbootExpressMiddleware(distPath, options) {
     }
 
     function failure(error) {
-      if (error.name === "UnrecognizedURLError") {
+      if (error.name === "UnrecognizedURLError" || error.name === "TransitionAborted") {
         next();
       } else {
         log(500, "Unknown Error: " + error.stack);


### PR DESCRIPTION
https://github.com/ember-fastboot/ember-cli-fastboot/issues/202

I will also include tests to validate this.

Seem similar to how Ember's extension of RSVP handles this https://github.com/emberjs/ember.js/blob/f6bad3dad476f952d79c3386bf9f7be12b075380/packages/ember-runtime/lib/ext/rsvp.js#L33-L40