### PR TITLE
UnrecognizedURLError should send 404

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,8 +58,8 @@ function fastbootExpressMiddleware(distPath, options) {
     }
 
     function failure(error) {
-      if (error.name !== "UnrecognizedURLError") {
-        res.status(500);
+      if (error.name === "UnrecognizedURLError") {
+        res.status(404);
       }
       next(error);
     }


### PR DESCRIPTION
It's already giving 500, what we need to do is specifically check for UnrecognizedURLError and send out 404.