### PR TITLE
Set the entry point to the built cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fastboot-express-middleware",
   "version": "1.0.0-rc.4",
   "description": "An Express middleware for rendering Ember apps with FastBoot",
-  "main": "src/index.js",
+  "main": "dist/cjs/index.js",
   "scripts": {
     "build": "ember build",
     "prepublish": "npm run build",


### PR DESCRIPTION
The files in `dist/` was never loaded and it blows up on node 0.12:

```bash
$ node fastboot-app-server.js
/Users/kitsunde/Development/ember-app-server-404/node_modules/fastboot-express-middleware/src/index.js:5
  const FastBoot = require('fastboot');
  ^^^^^
```

This follow the instructions on https://github.com/monegraph/broccoli-module-alchemist and sets the entry point to the dist file. Further the reason why it was working under travis is probably because of `alchemistRequire` here https://github.com/ember-fastboot/fastboot-express-middleware/blob/master/test/middleware-test.js#L7

