### PR TITLE
Ensure 404's receive the proper response code.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,10 +58,12 @@ function fastbootExpressMiddleware(distPath, options) {
     }
 
     function failure(error) {
-      if (error.name !== "UnrecognizedURLError") {
+      if (error.name === "UnrecognizedURLError") {
+        next();
+      } else {
         res.status(500);
+        next(error);
       }
-      next(error);
     }
   };
 }

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -52,6 +52,17 @@ describe("FastBoot", function() {
       });
   });
 
+  it("returns 404 when navigating to a URL that doesn't exist", function() {
+    let middleware = fastbootMiddleware(fixture('basic-app'));
+    server = new TestHTTPServer(middleware);
+
+    return server.start()
+      .then(() => server.request('/foo-bar-baz/non-existent'))
+      .catch((result) => {
+        expect(result.statusCode).to.equal(404);
+      });
+  });
+
   it("returns a 500 error if an error occurs", function() {
     let middleware = fastbootMiddleware({
       distPath: fixture('rejected-promise')


### PR DESCRIPTION
Prior to this change, requesting a URL that did not exist in the app resulted in a 500 response code (which is not correct).

When we encounter an unrecognized URL we should simply call `next` and allow any downstream middlewares to handle the request. If nothing handles the request, Express will set the status code to 404 on its own.

@kratiahuja / @rwjblue paired on this...

Closes https://github.com/ember-fastboot/fastboot-express-middleware/pull/15.