### PR TITLE
Drop broccoli-alchemist-install plugin

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,7 +1,0 @@
-var alchemist = require('broccoli-module-alchemist');
-
-module.exports = function() {
-  return alchemist({
-    targets: ['cjs']
-  });
-};

--- a/package.json
+++ b/package.json
@@ -2,11 +2,8 @@
   "name": "fastboot-express-middleware",
   "version": "1.0.0-rc.6",
   "description": "An Express middleware for rendering Ember apps with FastBoot",
-  "main": "dist/cjs/index.js",
+  "main": "src/index.js",
   "scripts": {
-    "build": "ember build",
-    "prepublish": "npm run build",
-    "postinstall": "broccoli-module-alchemist-install",
     "test": "mocha"
   },
   "repository": {
@@ -31,7 +28,6 @@
   "devDependencies": {
     "babel-core": "^6.11.4",
     "babel-preset-es2015": "^6.9.0",
-    "broccoli-module-alchemist": "^0.2.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "ember-cli": "^2.7.0",
@@ -41,7 +37,6 @@
     "request-promise": "^3.0.0"
   },
   "dependencies": {
-    "broccoli-module-alchemist-install": "^0.1.1",
     "chalk": "^1.1.3",
     "fastboot": "^1.0.0-rc.3"
   }

--- a/test/helpers/test-http-server.js
+++ b/test/helpers/test-http-server.js
@@ -2,8 +2,7 @@
 
 const express            = require('express');
 const request            = require('request-promise');
-const alchemistRequire   = require('broccoli-module-alchemist/require');
-const fastbootMiddleware = alchemistRequire('index');
+const fastbootMiddleware = require('./../../src/index');
 
 let serverID = 0;
 

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -3,8 +3,7 @@
 const expect             = require('chai').expect;
 const path               = require('path');
 const FastBoot           = require('fastboot');
-const alchemistRequire   = require('broccoli-module-alchemist/require');
-const fastbootMiddleware = alchemistRequire('index');
+const fastbootMiddleware = require('./../src/index');
 const fixture            = require('./helpers/fixture-path');
 const TestHTTPServer     = require('./helpers/test-http-server');
 


### PR DESCRIPTION
Now that we have dropped Node 0.12 support, we no longer need this broccoli plugin. Dropping this and changing the main entry fixes the tests in ember-cli-fastboot.

The reason for tests failing randomly in `ember-cli-fastboot` when bumping `fastboot-express-middleware` to `1.0.0-rc-6` was because the entry was changed to `dist/cjs/index` in this [PR](https://github.com/ember-fastboot/fastboot-express-middleware/commit/d2dad3ff613ce7e1f7cecd6ad407f1ce6a173e25). This only works on `postInstall` which does not play nicely with `ember-cli-addon-test`. I don't understand exactly why they don't play well. 

I confirmed the [tests in `ember-cli-fastboot` pass now](https://github.com/kratiahuja/ember-cli-fastboot/commits/bump-middleware) by pointing fastboot-express-middleware to this SHA. 

**NOTE**: We need another release of `fastboot-express-middleware`

cc: @rwjblue @danmcclain @tomdale 
