### PR TITLE
Added option to enable post processing fastboot response

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ app.get('/*', middleware);
 fastboot.reload();
 ```
 
+## Post processing
+
+If you want to work on the html response after fastboot is done with its work,
+you can set an option to include other middleware's in the chain.
+
+```js
+var myMiddleware = function(req, res) {
+    res.send(req.html);
+};
+
+app.use(fastbootMiddleware({
+  distPath: 'path/to/dist',
+  postProcess: true
+}));
+app.get('/*', myMiddleware);
+```
+
 [ember-cli-fastboot]: https://github.com/ember-fastboot/ember-cli-fastboot
 
 ## Tests

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,11 @@ function fastbootExpressMiddleware(distPath, options) {
             next(result.error);
           }
 
+          if (opts.postProcess) {
+            req.html = html;
+            return next();
+          }
+
           log(result.statusCode, statusMessage + path);
           res.status(result.statusCode);
           res.send(html);

--- a/test/helpers/mock-middleware.js
+++ b/test/helpers/mock-middleware.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function(req, res) {
+    res.set('x-test-middleware', 'true');
+    res.send(req.html);
+};

--- a/test/helpers/test-http-server.js
+++ b/test/helpers/test-http-server.js
@@ -3,6 +3,7 @@
 const express            = require('express');
 const request            = require('request-promise');
 const fastbootMiddleware = require('./../../src/index');
+const mockMiddleware     = require('./mock-middleware');
 
 let serverID = 0;
 
@@ -18,7 +19,13 @@ class TestHTTPServer {
     let options = this.options;
     let app = express();
 
-    app.get('/*', this.middleware);
+    if (options.postProcess) {
+      app.use(this.middleware);
+      app.use(mockMiddleware);
+      app.get('/*');
+    } else {
+      app.get('/*', this.middleware);
+    }
 
     if (options.errorHandling) {
       app.use((err, req, res, next) => {

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -228,4 +228,20 @@ describe("FastBoot", function() {
     });
   });
 
+  describe('checks middleware chain', function() {
+    it('chains when it has post process', function() {
+      let middleware = fastbootMiddleware({
+        distPath: fixture('basic-app'),
+        postProcess: true
+      });
+      server = new TestHTTPServer(middleware, { postProcess: true });
+
+      return server.start()
+        .then(() => server.request('/', { resolveWithFullResponse: true }))
+        .then(({ body, statusCode, headers }) => {
+          expect(statusCode).to.equal(200);
+          expect(headers['x-test-middleware']).to.match(/true/);
+        });
+    });
+  });
 });


### PR DESCRIPTION
Motivation: If a developer wants to do some extra parse in the response created by fastboot. The only option to use other middleware's is when fastboot throws an error. This will enable the middleware chain to be open.

Related issue: https://github.com/ember-fastboot/fastboot-express-middleware/issues/30