### PR TITLE
Fix setting multiple cookie headers in the response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,9 +39,6 @@ function fastbootExpressMiddleware(distPath, options) {
         let cookies = new Map();
 
         for (let [name, value] of headers.entries()) {
-          let name = pair[0];
-          let value = pair[1];
-
           if (name.toLowerCase() === 'set-cookie') {
             let cookieName = value.split('=')[0];
             cookies.set(cookieName, value);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 function fastbootExpressMiddleware(distPath, options) {
   let opts = options;
 
@@ -37,16 +36,27 @@ function fastbootExpressMiddleware(distPath, options) {
       responseBody.then(body => {
         let headers = result.headers;
         let statusMessage = result.error ? 'NOT OK ' : 'OK ';
-    
-        for (var pair of headers.entries()) {
-          res.set(pair[0], pair[1]);
+        let cookies = {};
+
+        for (let pair of headers.entries()) {
+          let name = pair[0];
+          let value = pair[1];
+
+          if (pair[0].toLowerCase() === 'set-cookie') {
+            let cookieName = value.split('=')[0];
+            cookies[cookieName] = value;
+          } else {
+            res.set(name, value);
+          }
         }
-    
+
+        res.set('Set-Cookie', Object.keys(cookies).map(k => cookies[k]));
+
         if (result.error) {
           log("RESILIENT MODE CAUGHT:", result.error.stack);
           next(result.error);
         }
-    
+
         log(result.statusCode, statusMessage + path);
         res.status(result.statusCode);
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,21 +36,23 @@ function fastbootExpressMiddleware(distPath, options) {
       responseBody.then(body => {
         let headers = result.headers;
         let statusMessage = result.error ? 'NOT OK ' : 'OK ';
-        let cookies = {};
+        let cookies = new Map();
 
-        for (let pair of headers.entries()) {
+        for (let [name, value] of headers.entries()) {
           let name = pair[0];
           let value = pair[1];
 
-          if (pair[0].toLowerCase() === 'set-cookie') {
+          if (name.toLowerCase() === 'set-cookie') {
             let cookieName = value.split('=')[0];
-            cookies[cookieName] = value;
+            cookies.set(cookieName, value);
           } else {
             res.set(name, value);
           }
         }
 
-        res.set('Set-Cookie', Object.keys(cookies).map(k => cookies[k]));
+        if (cookies.length > 0) {
+          res.set('Set-Cookie', cookies.values());
+        }
 
         if (result.error) {
           log("RESILIENT MODE CAUGHT:", result.error.stack);

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -255,6 +255,20 @@ describe("FastBoot", function() {
               expect(body).to.match(/hello world/);
             });
         });
+
+        it("can return multiple cookie headers", function() {
+          let middleware = fastbootMiddleware({
+            distPath: fixture('basic-app'),
+            chunkedResponse
+          });
+          server = new TestHTTPServer(middleware);
+
+          return server.start()
+            .then(() => server.request('/', { resolveWithFullResponse: true }))
+            .then(({ headers }) => {
+              expect(headers['set-cookie']).to.eql(['first-cookie=first', 'second-cookie=second']);
+            });
+        });
       });
     });
   });


### PR DESCRIPTION
Patches #33 and https://github.com/simplabs/ember-cookies/issues/133.

Cookies were previously set together with the other headers. This meant that if you were to set more than one cookie in FastBoot, each subsequent cookie would overwrite the `Set-Cookie` header and only the last cookie would be sent in the response. This particularly affects `ember-simple-auth`.

This commit extracts the cookie headers, dedups them by name and sets the header at once to set multiple cookies.

This doesn't use `res.cookie` because we're already dealing with serialized headers.
Should be compliant down to node 4.

#### Todo:
* [ ] Set cookies in the test app to make the tests pass. How do we do this?