### PR TITLE
Add Content-Type: text/html; charset-utf8

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ function fastbootExpressMiddleware(distPath, options) {
     
         log(result.statusCode, statusMessage + path);
         res.status(result.statusCode);
+        res.type('text/html');
 
         if (typeof body === 'string') {
           res.send(body);


### PR DESCRIPTION
This is lightly tested on my local machine. I think we need to add this because the initial FastBoot request is missing a content-type header. See my issue here: https://github.com/ember-fastboot/fastboot-app-server/issues/78

This is important because some Node-based crawlers simply break without a content-type header. How ironic if this is hurting SEO for production sites 😛 