### PR TITLE
Change test strings for clearer picture of what's going on

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,16 +37,16 @@ function fastbootExpressMiddleware(distPath, options) {
       responseBody.then(body => {
         let headers = result.headers;
         let statusMessage = result.error ? 'NOT OK ' : 'OK ';
-    
+
         for (var pair of headers.entries()) {
           res.set(pair[0], pair[1]);
         }
-    
+
         if (result.error) {
           log("RESILIENT MODE CAUGHT:", result.error.stack);
           next(result.error);
         }
-    
+
         log(result.statusCode, statusMessage + path);
         res.status(result.statusCode);
 

--- a/test/fixtures/rejected-promise/index.html
+++ b/test/fixtures/rejected-promise/index.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    hello world
+    Original body
     <!-- EMBER_CLI_FASTBOOT_BODY -->
   </body>
 </html>

--- a/test/helpers/test-http-server.js
+++ b/test/helpers/test-http-server.js
@@ -36,7 +36,7 @@ class TestHTTPServer {
     }
 
     return new Promise((resolve, reject) => {
-      let port = options.port || 3000;
+      let port = options.port || 5000;
       let host = options.host || 'localhost';
 
       let listener = app.listen(port, host, () => {

--- a/test/helpers/test-http-server.js
+++ b/test/helpers/test-http-server.js
@@ -31,7 +31,7 @@ class TestHTTPServer {
       app.use((err, req, res, next) => {
         res.set('x-test-recovery', 'recovered response');
         res.status(200);
-        res.send('hello world');
+        res.send('special error handling');
       });
     }
 

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -150,10 +150,11 @@ describe("FastBoot", function() {
           .then(() => server.request('/'))
           .catch(err => {
             expect(err.message).to.match(/Rejected on purpose/);
+            expect(err.response.body).to.match(/error/i);
           });
       });
 
-      describe('when reslient mode is enabled', function () {
+      describe('when resilient mode is enabled', function () {
         it("renders no FastBoot markup", function() {
           let middleware = fastbootMiddleware({
             distPath: fixture('rejected-promise'),
@@ -166,6 +167,7 @@ describe("FastBoot", function() {
             .then(() => server.request('/'))
             .then(html => {
               expect(html).to.not.match(/error/);
+              expect(html).to.match(/Original body/);
             });
         });
 
@@ -182,7 +184,7 @@ describe("FastBoot", function() {
             .then(({ body, statusCode, headers }) => {
               expect(statusCode).to.equal(200);
               expect(headers['x-test-error']).to.match(/error handler called/);
-              expect(body).to.match(/hello world/);
+              expect(body).to.match(/Original body/);
             });
         });
 
@@ -200,7 +202,7 @@ describe("FastBoot", function() {
               expect(statusCode).to.equal(200);
               expect(headers['x-test-error']).to.not.match(/error handler called/);
               expect(body).to.not.match(/error/);
-              expect(body).to.match(/hello world/);
+              expect(body).to.match(/Original body/);
             });
         });
 
@@ -217,7 +219,7 @@ describe("FastBoot", function() {
             .then(({ body, statusCode, headers }) => {
               expect(statusCode).to.equal(200);
               expect(headers['x-test-recovery']).to.match(/recovered response/);
-              expect(body).to.match(/hello world/);
+              expect(body).to.equal('special error handling');
             });
         });
       });
@@ -233,9 +235,10 @@ describe("FastBoot", function() {
 
           return server.start()
             .then(() => server.request('/', { resolveWithFullResponse: true }))
-            .catch(({ statusCode, response: { headers } }) => {
+            .catch(({ body, statusCode, response: { headers } }) => {
               expect(statusCode).to.equal(500);
               expect(headers['x-test-error']).to.match(/error handler called/);
+              expect(body).to.be.an('undefined');
             });
         });
 
@@ -252,7 +255,7 @@ describe("FastBoot", function() {
             .then(({ body, statusCode, headers }) => {
               expect(statusCode).to.equal(200);
               expect(headers['x-test-recovery']).to.match(/recovered response/);
-              expect(body).to.match(/hello world/);
+              expect(body).to.equal('special error handling');
             });
         });
       });


### PR DESCRIPTION
It was unclear to me what scenarios would legitimately render a body that matched "error" vs when "hello world" was rendered because index.html was rendered or because the middleware was rendering that string directly.

This changes index.html to contain the string "Original body" and the middleware to send the string "special error handling" to disambiguate the two.

Additionally it adds some assertions around what the body _should_ match for examples that only had what it _should not_ match.


On a related note: I'm still trying to figure out why index.html is rendered fine with `resilient` enabled in these tests but not in `fastboot-app-server` tests (even after updating fastboot-app-server to properly pass `resilient` through).